### PR TITLE
Use native driver

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -197,6 +197,7 @@ export default class Row extends Component {
       Animated.timing(this._animatedLocation, {
         toValue: nextLocation,
         duration: 300,
+        useNativeDriver: false,
       }).start(() => {
         this._isAnimationRunning = false;
       });


### PR DESCRIPTION
This was causing a warning in React Native because `useNativeDriver` is a required prop in `Animated.timing` now.

Someone else already created [PR #222](https://github.com/gitim/react-native-sortable-list/pull/222/files) to address this issue on the parent project.

This branch is based off of the `fix_react_native_warnings` branch, so #1 should be merged before this PR.